### PR TITLE
Prepare support auto resolve params

### DIFF
--- a/app/Constracts/ExtensionConstract.php
+++ b/app/Constracts/ExtensionConstract.php
@@ -2,8 +2,8 @@
 
 namespace App\Constracts;
 
+use App\Core\Application;
 use DI\Container;
-use Slim\App;
 
 interface ExtensionConstract
 {
@@ -15,7 +15,7 @@ interface ExtensionConstract
 
     public function setExtensionDir($extensionDir);
 
-    public function setApp(App &$app);
+    public function setApp(Application &$app);
 
     public function setContainer(Container &$container);
 

--- a/app/Core/Application.php
+++ b/app/Core/Application.php
@@ -1,0 +1,218 @@
+<?php
+
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace App\Core;
+
+use App\Core\Routing\RouteCollectorProxy;
+use App\Http\ResponseEmitter\ResponseEmitter;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LoggerInterface;
+use Slim\CallableResolver;
+use Slim\Factory\ServerRequestCreatorFactory;
+use Slim\Interfaces\CallableResolverInterface;
+use Slim\Interfaces\MiddlewareDispatcherInterface;
+use Slim\Interfaces\RouteCollectorInterface;
+use Slim\Interfaces\RouteResolverInterface;
+use Slim\Middleware\BodyParsingMiddleware;
+use Slim\Middleware\ErrorMiddleware;
+use Slim\Middleware\RoutingMiddleware;
+use Slim\Routing\RouteResolver;
+use Slim\Routing\RouteRunner;
+
+use function strtoupper;
+
+class Application extends RouteCollectorProxy implements RequestHandlerInterface
+{
+    /**
+     * Current version
+     *
+     * @var string
+     */
+    public const VERSION = '4.12.0';
+
+    protected RouteResolverInterface $routeResolver;
+
+    protected MiddlewareDispatcherInterface $middlewareDispatcher;
+
+    public function __construct(
+        ResponseFactoryInterface $responseFactory,
+        ?ContainerInterface $container = null,
+        ?CallableResolverInterface $callableResolver = null,
+        ?RouteCollectorInterface $routeCollector = null,
+        ?RouteResolverInterface $routeResolver = null,
+        ?MiddlewareDispatcherInterface $middlewareDispatcher = null
+    ) {
+        parent::__construct(
+            $responseFactory,
+            $callableResolver ?? new CallableResolver($container),
+            $container,
+            $routeCollector
+        );
+
+        $this->routeResolver = $routeResolver ?? new RouteResolver($this->routeCollector);
+        $routeRunner = new RouteRunner($this->routeResolver, $this->routeCollector->getRouteParser(), $this);
+
+        if (!$middlewareDispatcher) {
+            $middlewareDispatcher = new MiddlewareDispatcher($routeRunner, $this->callableResolver, $container);
+        } else {
+            $middlewareDispatcher->seedMiddlewareStack($routeRunner);
+        }
+
+        $this->middlewareDispatcher = $middlewareDispatcher;
+    }
+
+    /**
+     * @return RouteResolverInterface
+     */
+    public function getRouteResolver(): RouteResolverInterface
+    {
+        return $this->routeResolver;
+    }
+
+    /**
+     * @return MiddlewareDispatcherInterface
+     */
+    public function getMiddlewareDispatcher(): MiddlewareDispatcherInterface
+    {
+        return $this->middlewareDispatcher;
+    }
+
+    /**
+     * @param MiddlewareInterface|string|callable $middleware
+     */
+    public function add($middleware): self
+    {
+        $this->middlewareDispatcher->add($middleware);
+        return $this;
+    }
+
+    /**
+     * @param MiddlewareInterface $middleware
+     */
+    public function addMiddleware(MiddlewareInterface $middleware): self
+    {
+        $this->middlewareDispatcher->addMiddleware($middleware);
+        return $this;
+    }
+
+    /**
+     * Add the Slim built-in routing middleware to the app middleware stack
+     *
+     * This method can be used to control middleware order and is not required for default routing operation.
+     *
+     * @return RoutingMiddleware
+     */
+    public function addRoutingMiddleware(): RoutingMiddleware
+    {
+        $routingMiddleware = new RoutingMiddleware(
+            $this->getRouteResolver(),
+            $this->getRouteCollector()->getRouteParser()
+        );
+        $this->add($routingMiddleware);
+        return $routingMiddleware;
+    }
+
+    /**
+     * Add the Slim built-in error middleware to the app middleware stack
+     *
+     * @param bool                 $displayErrorDetails
+     * @param bool                 $logErrors
+     * @param bool                 $logErrorDetails
+     * @param LoggerInterface|null $logger
+     *
+     * @return ErrorMiddleware
+     */
+    public function addErrorMiddleware(
+        bool $displayErrorDetails,
+        bool $logErrors,
+        bool $logErrorDetails,
+        ?LoggerInterface $logger = null
+    ): ErrorMiddleware {
+        $errorMiddleware = new ErrorMiddleware(
+            $this->getCallableResolver(),
+            $this->getResponseFactory(),
+            $displayErrorDetails,
+            $logErrors,
+            $logErrorDetails,
+            $logger
+        );
+        $this->add($errorMiddleware);
+        return $errorMiddleware;
+    }
+
+    /**
+     * Add the Slim body parsing middleware to the app middleware stack
+     *
+     * @param callable[] $bodyParsers
+     *
+     * @return BodyParsingMiddleware
+     */
+    public function addBodyParsingMiddleware(array $bodyParsers = []): BodyParsingMiddleware
+    {
+        $bodyParsingMiddleware = new BodyParsingMiddleware($bodyParsers);
+        $this->add($bodyParsingMiddleware);
+        return $bodyParsingMiddleware;
+    }
+
+    /**
+     * Run application
+     *
+     * This method traverses the application middleware stack and then sends the
+     * resultant Response object to the HTTP client.
+     *
+     * @param ServerRequestInterface|null $request
+     * @return void
+     */
+    public function run(?ServerRequestInterface $request = null): void
+    {
+        if (!$request) {
+            $serverRequestCreator = ServerRequestCreatorFactory::create();
+            $request = $serverRequestCreator->createServerRequestFromGlobals();
+        }
+
+        $response = $this->handle($request);
+        $responseEmitter = new ResponseEmitter();
+        $responseEmitter->emit($response);
+    }
+
+    /**
+     * Handle a request
+     *
+     * This method traverses the application middleware stack and then returns the
+     * resultant Response object.
+     *
+     * @param ServerRequestInterface $request
+     * @return ResponseInterface
+     */
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $response = $this->middlewareDispatcher->handle($request);
+
+        /**
+         * This is to be in compliance with RFC 2616, Section 9.
+         * If the incoming request method is HEAD, we need to ensure that the response body
+         * is empty as the request may fall back on a GET route handler due to FastRoute's
+         * routing logic which could potentially append content to the response body
+         * https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.4
+         */
+        $method = strtoupper($request->getMethod());
+        if ($method === 'HEAD') {
+            $emptyBody = $this->responseFactory->createResponse()->getBody();
+            return $response->withBody($emptyBody);
+        }
+
+        return $response;
+    }
+}

--- a/app/Core/Application.php
+++ b/app/Core/Application.php
@@ -28,6 +28,7 @@ use Slim\Interfaces\RouteResolverInterface;
 use Slim\Middleware\BodyParsingMiddleware;
 use Slim\Middleware\ErrorMiddleware;
 use Slim\Middleware\RoutingMiddleware;
+use Slim\MiddlewareDispatcher;
 use Slim\Routing\RouteResolver;
 use Slim\Routing\RouteRunner;
 

--- a/app/Core/Extension.php
+++ b/app/Core/Extension.php
@@ -22,7 +22,7 @@ abstract class Extension implements ExtensionConstract
     /**
      * Slim app
      *
-     * @var \Slim\App
+     * @var \App\Core\Application
      */
     protected $app;
 
@@ -50,7 +50,7 @@ abstract class Extension implements ExtensionConstract
         return boolval($this->isBuiltIn);
     }
 
-    public function setApp(App &$app)
+    public function setApp(Application &$app)
     {
         $this->app = $app;
     }

--- a/app/Core/Factory/AppFactory.php
+++ b/app/Core/Factory/AppFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Core\Factory;
+
+use App\Core\Application;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Slim\Factory\AppFactory as SlimAppFactory;
+use Slim\Interfaces\CallableResolverInterface;
+use Slim\Interfaces\MiddlewareDispatcherInterface;
+use Slim\Interfaces\RouteCollectorInterface;
+use Slim\Interfaces\RouteResolverInterface;
+
+class AppFactory extends SlimAppFactory
+{
+    public static function createApp(
+        ?ResponseFactoryInterface $responseFactory = null,
+        ?ContainerInterface $container = null,
+        ?CallableResolverInterface $callableResolver = null,
+        ?RouteCollectorInterface $routeCollector = null,
+        ?RouteResolverInterface $routeResolver = null,
+        ?MiddlewareDispatcherInterface $middlewareDispatcher = null
+    ): Application {
+        static::$responseFactory = $responseFactory ?? static::$responseFactory;
+        return new Application(
+            self::determineResponseFactory(),
+            $container ?? static::$container,
+            $callableResolver ?? static::$callableResolver,
+            $routeCollector ?? static::$routeCollector,
+            $routeResolver ?? static::$routeResolver,
+            $middlewareDispatcher ?? static::$middlewareDispatcher
+        );
+    }
+}

--- a/app/Core/Handlers/Strategies/RequestResponse.php
+++ b/app/Core/Handlers/Strategies/RequestResponse.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Core\Handlers\Strategies;
+
+use App\Exceptions\CanNotResolveParamException;
+use Closure;
+use Laravel\SerializableClosure\Support\ReflectionClosure;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use ReflectionClass;
+use ReflectionFunction;
+use ReflectionMethod;
+use ReflectionNamedType;
+use Slim\Handlers\Strategies\RequestResponse as SlimRequestResponse;
+
+class RequestResponse extends SlimRequestResponse
+{
+    /**
+     * @var \Psr\Container\ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * Invoke a route callable with request, response, and all route parameters
+     * as an array of arguments.
+     *
+     * @param array<string, string>  $routeArguments
+     */
+    public function resolve(
+        callable $callable,
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        array $routeArguments,
+        ContainerInterface $container
+    ): ResponseInterface {
+        $this->container = $container;
+
+        foreach ($routeArguments as $k => $v) {
+            $request = $request->withAttribute($k, $v);
+        }
+
+        // Resolved params order
+        $params = $this->resolveParams($callable, $request, $response);
+
+        // Send $routeArguments to last param
+        array_push(
+            $params,
+            $routeArguments
+        );
+
+        return call_user_func_array($callable, $params);
+    }
+
+    protected function resolveTheParamValue(?ReflectionNamedType $type, string $namedParam)
+    {
+        if (!is_null($type) && $this->container->has($type->getName())) {
+            return $this->container->get($type->getName());
+        }
+        if ($this->container->has($namedParam)) {
+            return $this->container->get($namedParam);
+        }
+        throw new CanNotResolveParamException();
+    }
+
+
+    protected function resolveParamsForClosure($callable)
+    {
+        $params = [];
+
+        $methodRefl = new ReflectionClosure($callable);
+        if ($methodRefl->getNumberOfParameters() > 0) {
+            foreach ($methodRefl->getParameters() as $param) {
+                $params[] = $this->resolveTheParamValue(
+                    $param->getType(),
+                    $param->getName()
+                );
+            }
+        }
+
+        return $params;
+    }
+
+    protected function resolveParamsForStaticMethod($callable): array
+    {
+        $params = [];
+
+        $funcRefl = new ReflectionFunction($callable);
+
+        if ($funcRefl->getNumberOfParameters() > 0) {
+            foreach ($funcRefl->getParameters() as $param) {
+                $params[] = $this->resolveTheParamValue(
+                    $param->getType(),
+                    $param->getName()
+                );
+            }
+        }
+
+        return $params;
+    }
+
+    protected function resolveParamsForMethod($callable): array
+    {
+        $params = [];
+        if (count($callable) === 2) {
+            $methodRefl = new ReflectionMethod($callable[0], $callable[1]);
+            if ($methodRefl->getNumberOfParameters() > 0) {
+                foreach ($methodRefl->getParameters() as $param) {
+                    $params[] = $this->resolveTheParamValue(
+                        $param->getType(),
+                        $param->getName()
+                    );
+                }
+            }
+        }
+
+        return $params;
+    }
+
+    protected function resolveParams($callable, $request, $response): array
+    {
+        try {
+            if ($callable instanceof Closure) {
+                return $this->resolveParamsForClosure($callable);
+            } elseif (is_string($callable)) {
+                return $this->resolveParamsForStaticMethod($callable);
+            } elseif (is_array($callable) && is_object($callable[0])) {
+                $reflectCls = new ReflectionClass($callable[0]);
+                if (!$reflectCls->isAnonymous()) {
+                    return $this->resolveParamsForMethod($callable);
+                }
+            }
+        } catch (CanNotResolveParamException $e) {
+            // Send PHP error logs to debug
+            error_log($e->getMessage());
+        }
+
+        return [$request, $response];
+    }
+}

--- a/app/Core/MiddlewareDispatcher.php
+++ b/app/Core/MiddlewareDispatcher.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Core;
+
+use Slim\MiddlewareDispatcher as SlimMiddlewareDispatcher;
+
+class MiddlewareDispatcher extends SlimMiddlewareDispatcher
+{
+}

--- a/app/Core/MiddlewareDispatcher.php
+++ b/app/Core/MiddlewareDispatcher.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace App\Core;
-
-use Slim\MiddlewareDispatcher as SlimMiddlewareDispatcher;
-
-class MiddlewareDispatcher extends SlimMiddlewareDispatcher
-{
-}

--- a/app/Core/Routing/Route.php
+++ b/app/Core/Routing/Route.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Core\Routing;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Slim\Handlers\Strategies\RequestHandler;
+use Slim\Interfaces\AdvancedCallableResolverInterface;
+use Slim\Routing\Route as SlimRoute;
+
+class Route extends SlimRoute
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        if ($this->callableResolver instanceof AdvancedCallableResolverInterface) {
+            $callable = $this->callableResolver->resolveRoute($this->callable);
+        } else {
+            $callable = $this->callableResolver->resolve($this->callable);
+        }
+        $strategy = $this->invocationStrategy;
+
+
+        /** @var string[] $strategyImplements */
+        $strategyImplements = class_implements($strategy);
+
+        if (
+            is_array($callable)
+            && $callable[0] instanceof RequestHandlerInterface
+            && !in_array(RequestHandlerInvocationStrategyInterface::class, $strategyImplements)
+        ) {
+            $strategy = new RequestHandler();
+        }
+
+        $response = $this->responseFactory->createResponse();
+        return $strategy($callable, $request, $response, $this->arguments);
+    }
+}

--- a/app/Core/Routing/Route.php
+++ b/app/Core/Routing/Route.php
@@ -2,15 +2,56 @@
 
 namespace App\Core\Routing;
 
+use App\Core\Handlers\Strategies\RequestResponse;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Slim\Handlers\Strategies\RequestHandler;
 use Slim\Interfaces\AdvancedCallableResolverInterface;
+use Slim\Interfaces\CallableResolverInterface;
+use Slim\Interfaces\InvocationStrategyInterface;
+use Slim\MiddlewareDispatcher;
 use Slim\Routing\Route as SlimRoute;
 
 class Route extends SlimRoute
 {
+    /**
+     * @param string[]                         $methods    The route HTTP methods
+     * @param string                           $pattern    The route pattern
+     * @param callable|string                  $callable   The route callable
+     * @param ResponseFactoryInterface         $responseFactory
+     * @param CallableResolverInterface        $callableResolver
+     * @param ContainerInterface|null          $container
+     * @param InvocationStrategyInterface|null $invocationStrategy
+     * @param RouteGroupInterface[]            $groups     The parent route groups
+     * @param int                              $identifier The route identifier
+     */
+    public function __construct(
+        array $methods,
+        string $pattern,
+        $callable,
+        ResponseFactoryInterface $responseFactory,
+        CallableResolverInterface $callableResolver,
+        ?ContainerInterface $container = null,
+        ?InvocationStrategyInterface $invocationStrategy = null,
+        array $groups = [],
+        int $identifier = 0
+    ) {
+        $this->methods = $methods;
+        $this->pattern = $pattern;
+        $this->callable = $callable;
+        $this->responseFactory = $responseFactory;
+        $this->callableResolver = $callableResolver;
+        $this->container = $container;
+        $this->invocationStrategy = $invocationStrategy ?? new RequestResponse();
+        $this->groups = $groups;
+        $this->identifier = 'route' . $identifier;
+        $this->middlewareDispatcher = new MiddlewareDispatcher($this, $callableResolver, $container);
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -21,8 +62,10 @@ class Route extends SlimRoute
         } else {
             $callable = $this->callableResolver->resolve($this->callable);
         }
+        /**
+         * @var \App\Core\Handlers\Strategies\RequestResponse
+         */
         $strategy = $this->invocationStrategy;
-
 
         /** @var string[] $strategyImplements */
         $strategyImplements = class_implements($strategy);
@@ -32,10 +75,30 @@ class Route extends SlimRoute
             && $callable[0] instanceof RequestHandlerInterface
             && !in_array(RequestHandlerInvocationStrategyInterface::class, $strategyImplements)
         ) {
+            /**
+             * @var \Slim\Handlers\Strategies\RequestHandler;
+             */
             $strategy = new RequestHandler();
         }
 
         $response = $this->responseFactory->createResponse();
+
+        /**
+         * @var \DI\Container
+         */
+        $container = $this->container;
+
+        $container->set(RequestInterface::class, $request);
+        $container->set(ServerRequestInterface::class, $request);
+        $container->set('request', $request);
+
+        $container->set(ResponseInterface::class, $response);
+        $container->set('response', $response);
+
+        // Auto resolve params
+        if (is_a($strategy, RequestResponse::class)) {
+            return $strategy->resolve($callable, $request, $response, $this->arguments, $container);
+        }
         return $strategy($callable, $request, $response, $this->arguments);
     }
 }

--- a/app/Core/Routing/RouteCollector.php
+++ b/app/Core/Routing/RouteCollector.php
@@ -2,11 +2,37 @@
 
 namespace App\Core\Routing;
 
+use App\Core\Handlers\Strategies\RequestResponse;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Slim\Interfaces\CallableResolverInterface;
+use Slim\Interfaces\InvocationStrategyInterface;
 use Slim\Interfaces\RouteInterface;
+use Slim\Interfaces\RouteParserInterface;
 use Slim\Routing\RouteCollector as SlimRouteCollector;
+use Slim\Routing\RouteParser;
 
 class RouteCollector extends SlimRouteCollector
 {
+    public function __construct(
+        ResponseFactoryInterface $responseFactory,
+        CallableResolverInterface $callableResolver,
+        ?ContainerInterface $container = null,
+        ?InvocationStrategyInterface $defaultInvocationStrategy = null,
+        ?RouteParserInterface $routeParser = null,
+        ?string $cacheFile = null
+    ) {
+        $this->responseFactory = $responseFactory;
+        $this->callableResolver = $callableResolver;
+        $this->container = $container;
+        $this->defaultInvocationStrategy = $defaultInvocationStrategy ?? new RequestResponse();
+        $this->routeParser = $routeParser ?? new RouteParser($this);
+
+        if ($cacheFile) {
+            $this->setCacheFile($cacheFile);
+        }
+    }
+
     /**
      * @param string[]        $methods
      * @param callable|string $callable

--- a/app/Core/Routing/RouteCollector.php
+++ b/app/Core/Routing/RouteCollector.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Core\Routing;
+
+use Slim\Interfaces\RouteInterface;
+use Slim\Routing\RouteCollector as SlimRouteCollector;
+
+class RouteCollector extends SlimRouteCollector
+{
+    /**
+     * @param string[]        $methods
+     * @param callable|string $callable
+     */
+    protected function createRoute(array $methods, string $pattern, $callable): RouteInterface
+    {
+        return new Route(
+            $methods,
+            $pattern,
+            $callable,
+            $this->responseFactory,
+            $this->callableResolver,
+            $this->container,
+            $this->defaultInvocationStrategy,
+            $this->routeGroups,
+            $this->routeCounter
+        );
+    }
+}

--- a/app/Core/Routing/RouteCollectorProxy.php
+++ b/app/Core/Routing/RouteCollectorProxy.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Core\Routing;
+
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Slim\Interfaces\CallableResolverInterface;
+use Slim\Interfaces\RouteCollectorInterface;
+use Slim\Routing\RouteCollectorProxy as SlimRouteCollectorProxy;
+
+class RouteCollectorProxy extends SlimRouteCollectorProxy
+{
+    public function __construct(
+        ResponseFactoryInterface $responseFactory,
+        CallableResolverInterface $callableResolver,
+        ?ContainerInterface $container = null,
+        ?RouteCollectorInterface $routeCollector = null,
+        string $groupPattern = ''
+    ) {
+        $this->responseFactory = $responseFactory;
+        $this->callableResolver = $callableResolver;
+        $this->container = $container;
+        $this->routeCollector = $routeCollector ?? new RouteCollector($responseFactory, $callableResolver, $container);
+        $this->groupPattern = $groupPattern;
+    }
+}

--- a/app/Exceptions/CanNotResolveParamException.php
+++ b/app/Exceptions/CanNotResolveParamException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class CanNotResolveParamException extends Exception
+{
+}

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\Constracts\ControllerConstract;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class Controller implements ControllerConstract
 {

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -107,6 +107,10 @@ final class Bootstrap
         $middleware($this->app);
 
         // Register routes
+        $routes = require __DIR__ . '/../configs/routes.php';
+        $routes($app);
+
+        // Register routes
         $this->app->options('/{routes:.*}', function (Request $request, Response $response) {
             // CORS Pre-Flight OPTIONS Request Handler
             return $response;

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -108,7 +108,7 @@ final class Bootstrap
 
         // Register routes
         $routes = require __DIR__ . '/../configs/routes.php';
-        $routes($app);
+        $routes($this->app);
 
         // Register routes
         $this->app->options('/{routes:.*}', function (Request $request, Response $response) {

--- a/configs/middleware.php
+++ b/configs/middleware.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
+use App\Core\Application;
 use App\Http\Middleware\SessionMiddleware;
-use Slim\App;
 
-return function (App $app) {
+return function (Application $app) {
     $app->add(SessionMiddleware::class);
 };

--- a/configs/routes.php
+++ b/configs/routes.php
@@ -10,11 +10,6 @@ use Slim\App;
 use Slim\Interfaces\RouteCollectorProxyInterface as Group;
 
 return function (App $app) {
-    $app->options('/{routes:.*}', function (Request $request, Response $response) {
-        // CORS Pre-Flight OPTIONS Request Handler
-        return $response;
-    });
-
     $app->get('/', function (Request $request, Response $response) {
         $response->getBody()->write('Hello world!');
         return $response;

--- a/configs/routes.php
+++ b/configs/routes.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 use App\Application\Actions\User\ListUsersAction;
 use App\Application\Actions\User\ViewUserAction;
+use App\Core\Application;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\App;
 use Slim\Interfaces\RouteCollectorProxyInterface as Group;
 
-return function (App $app) {
+return function (Application $app) {
     $app->get('/', function (Request $request, Response $response) {
         $response->getBody()->write('Hello world!');
         return $response;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -48,7 +48,7 @@ class TestCase extends PHPUnit_TestCase
 
         // Instantiate the app
         AppFactory::setContainer($container);
-        $app = AppFactory::create();
+        $app = AppFactory::createApp();
 
         // Register middleware
         $middleware = require __DIR__ . '/../configs/middleware.php';

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -48,12 +48,15 @@ class TestCase extends PHPUnit_TestCase
 
         // Instantiate the app
         AppFactory::setContainer($container);
-        $app = AppFactory::createApp();
+        $app = AppFactory::create();
 
         // Register middleware
         $middleware = require __DIR__ . '/../configs/middleware.php';
         $middleware($app);
 
+        // Register routes
+        $routes = require __DIR__ . '/../configs/routes.php';
+        $routes($app);
 
         return $app;
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Tests;
 
+use App\Core\Application;
+use App\Core\Factory\AppFactory;
 use DI\ContainerBuilder;
 use Exception;
 use PHPUnit\Framework\TestCase as PHPUnit_TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\App;
-use Slim\Factory\AppFactory;
 use Slim\Psr7\Factory\StreamFactory;
 use Slim\Psr7\Headers;
 use Slim\Psr7\Request as SlimRequest;
@@ -24,7 +24,7 @@ class TestCase extends PHPUnit_TestCase
      * @return App
      * @throws Exception
      */
-    protected function getAppInstance(): App
+    protected function getAppInstance(): Application
     {
         // Instantiate PHP-DI ContainerBuilder
         $containerBuilder = new ContainerBuilder();
@@ -48,15 +48,12 @@ class TestCase extends PHPUnit_TestCase
 
         // Instantiate the app
         AppFactory::setContainer($container);
-        $app = AppFactory::create();
+        $app = AppFactory::createApp();
 
         // Register middleware
         $middleware = require __DIR__ . '/../configs/middleware.php';
         $middleware($app);
 
-        // Register routes
-        $routes = require __DIR__ . '/../configs/routes.php';
-        $routes($app);
 
         return $app;
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,6 +14,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Psr7\Factory\StreamFactory;
 use Slim\Psr7\Headers;
 use Slim\Psr7\Request as SlimRequest;
+use Slim\Psr7\Response;
 use Slim\Psr7\Uri;
 
 class TestCase extends PHPUnit_TestCase
@@ -56,7 +57,12 @@ class TestCase extends PHPUnit_TestCase
 
         // Register routes
         $routes = require __DIR__ . '/../configs/routes.php';
+        $app->options('/{routes:.*}', function (Request $request, Response $response) {
+            // CORS Pre-Flight OPTIONS Request Handler
+            return $response;
+        });
         $routes($app);
+
 
         return $app;
     }


### PR DESCRIPTION
The Slim route handle must be sent params order as sequence is Request, Response, args.

And does not support auto-resolve or use Dependence Injection to reuse initialized object

Puleeno CMS will be support it.

<img width="710" alt="Screen Shot 2023-08-26 at 18 30 21" src="https://github.com/puleeno/puleeno-cms/assets/22538657/1481fed4-42c6-42eb-a290-d61b51977a57">

<img width="682" alt="Screen Shot 2023-08-26 at 18 31 31" src="https://github.com/puleeno/puleeno-cms/assets/22538657/ae0df957-e5cd-4539-a5a6-b19a3ced1ebd">

<img width="707" alt="Screen Shot 2023-08-26 at 18 31 39" src="https://github.com/puleeno/puleeno-cms/assets/22538657/d52f9179-4bf8-4345-bbed-6f7b03dd4917">
